### PR TITLE
add additional search functionality

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,7 @@
+{{- define "main" -}}
+ <div class="FourOhFourCentered">
+   <h1>Page not found</h1>
+   <p>Sorry, that page isn't on this site.</p>
+   <p class="bottom">Please use the navigation menu above, or the <a href="/search">search</a> page to find another page.</p>
+ </div>
+{{- end }}

--- a/layouts/papers/single.html
+++ b/layouts/papers/single.html
@@ -3,7 +3,7 @@
 {{/* <p class="d-none"> Rendered from /layouts/papers/single.html </p> */}}
 
 <div class="my-3">
-  <h2>{{ .Title }}</h2>
+  <h1>{{ .Title }}</h1>
 </div>
 
 {{ partial "paper-card" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,16 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ .Title }}</title>
+    <title>
+    {{- if .IsHome -}}
+      Home | {{ .Site.Title }}
+    {{- else if .Page.Title -}}
+      {{ .Page.Title }} | {{ .Site.Title }}
+    {{- else -}}
+      {{ .Site.Title }}
+    {{- end -}}
+    </title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+     <link rel="canonical" href="{{ .Permalink }}" />
     {{ partial "style.html" . }}
   </head>


### PR DESCRIPTION
By changing it from h2 to h1, Pagefind will automatically find the source image and show that in the search metadata. 