### PR TITLE
Fixed Docker Environment

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.132.1
+      HUGO_VERSION: 0.161.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.20
+FROM alpine:latest
 
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "hugo=~v0.134.2"
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community "hugo~0.160.1-r1"
 
-RUN apk add --no-cache vim bash
+RUN apk add --no-cache vim bash npm
 
 WORKDIR /root/src
 
-CMD ["hugo", "server"]
+CMD ["sh", "-c", "echo '\n---------------------------------------------------' && echo '🚀 Dev server running at: http://localhost:1313/' && echo '---------------------------------------------------\n' && exec hugo server --bind 0.0.0.0 --port 1313 --baseURL http://localhost:1313/"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,13 @@
-version: "3"
-
 services:
   hugo:
     build: .
-    tty: true
-    network_mode: "host"
+    container_name: dasc-hugo
+    ports:
+      - "1313:1313"
     volumes:
       - .:/root/src
+    environment:
+      - HUGO_ENV=development
+    restart: unless-stopped
+    tty: true
+    stdin_open: true

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,7 +4,7 @@ title = 'DASC Lab UMich'
 buildFuture = true
 
 [permalinks]
-  blog = "/:filename/"
+  blog = "/:contentbasename/"
 
 [taxonomies]
 # person = "people"

--- a/readme.md
+++ b/readme.md
@@ -16,17 +16,20 @@ The github workflows will automatically deploy the new version of the website.
 
 ## Docker
 
-You can also use the dockerfiles here to do this. Simply run
+You can also use the docker compose setup here to do this. Simply run:
+```bash
+docker compose up
 ```
-docker compose build
-```
-to build the image, and then to run the container
-```
-docker compose up -d
-docker exec -it dasc-labgithubio-hugo-1 hugo server
-```
+This will build the image (if necessary) and start the server. It will print a clickable link to `http://localhost:1313/` directly in your terminal. Updates made to the local repo should automatically get rendered.
 
-This should print the location where the web server is available, and you can open it in a browser. Updates made to the local repo should automatically get rendered.
+If you prefer to run the container in the background, use:
+```bash
+docker compose up -d
+```
+You can then view the logs to see the clickable link by running:
+```bash
+docker compose logs -f hugo
+```
 
 ## Adding Content
 


### PR DESCRIPTION
Docker environment was not configured correctly to bind to host, leading to issues accessing the webpage from the docker environment.

Summary of Changes:
1) Configured hugo to bind to port 0.0.0.0:1313
2) Configured compose to expose port 1313 & bind to host
3) Modified docker to use alpine:latest
4) Migrated local environment to hugo 160.0.1-r1, & updated github actions accordingly
5) updated REAMDE to reflect new version & changes to docker useage